### PR TITLE
Search both .ssh/config and .ssh/known_hosts

### DIFF
--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -63,7 +63,7 @@ public:
 		QMutexLocker _ml(&mutex);
 		QDir dir(sshdir);
 
-		QString config_path = dir.filePath("config");
+		QString config_path = dir.filePath("known_hosts");
 
 		if (list && lastChecked >= QFileInfo(config_path).lastModified()) {
 			return;
@@ -89,15 +89,13 @@ public:
 				continue;
 			}
 
-			if (line.startsWith("host ", Qt::CaseInsensitive)) {
+                        QString hostnamelong = line.section(" ",0,0);
+                        QString hostname = hostnamelong.section(",",0,0);
 
-				QString hostname = line.mid(5).trimmed();
+                        SSHHost host;
+                        host.name = hostname;
 
-				SSHHost host;
-				host.name = hostname;
-
-				(*list) << host;
-			}
+                        (*list) << host;
 		}
 
 		config.close();

--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -183,7 +183,7 @@ void SSHRunner::run(const Plasma::RunnerContext &context, const Plasma::QueryMat
 
 	QString command = QString("ssh %1").arg(host);
 
-	QString konsole_command = QString("env TERM=xterm-color termite -e \"%1\"").arg(command);
+	QString konsole_command = QString("termite -e \"env TERM=xterm-color %1\"").arg(command);
 
 	KRun::runCommand(konsole_command, 0);
 }

--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -183,7 +183,7 @@ void SSHRunner::run(const Plasma::RunnerContext &context, const Plasma::QueryMat
 
 	QString command = QString("ssh %1").arg(host);
 
-	QString konsole_command = QString("konsole -e %1").arg(command);
+	QString konsole_command = QString("termite -e \"%1\"").arg(command);
 
 	KRun::runCommand(konsole_command, 0);
 }

--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -183,7 +183,7 @@ void SSHRunner::run(const Plasma::RunnerContext &context, const Plasma::QueryMat
 
 	QString command = QString("ssh %1").arg(host);
 
-	QString konsole_command = QString("termite -e \"%1\"").arg(command);
+	QString konsole_command = QString("env TERM=xterm-color termite -e \"%1\"").arg(command);
 
 	KRun::runCommand(konsole_command, 0);
 }


### PR DESCRIPTION
This set of changes searches both the .ssh/config and .ssh/known_hosts files for hosts to add to its list

It also merges in the upstream changes to use the user's configured default terminal, and adds quoting of the -e string.