### PR TITLE
Search both .ssh/config and .ssh/known_hosts

### DIFF
--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -186,10 +186,9 @@ void SSHRunner::run(const Plasma::RunnerContext &context, const Plasma::QueryMat
 
 	QString command = QString("ssh %1").arg(host);
 
-
         KConfigGroup config(KSharedConfig::openConfig(QStringLiteral("kdeglobals")), "General");
         QString terminal = config.readPathEntry("TerminalApplication",QStringLiteral("konsole"));
-	QString konsole_command = QString(terminal+" -e %1").arg(command);
+	QString konsole_command = QString(terminal+" -e \'%1\'").arg(command);
 
 	KRun::runCommand(konsole_command, 0);
 }

--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -66,7 +66,7 @@ public:
 		QMutexLocker _ml(&mutex);
 		QDir dir(sshdir);
 
-		QString config_path = dir.filePath("config");
+		QString config_path = dir.filePath("known_hosts");
 
 		if (list && lastChecked >= QFileInfo(config_path).lastModified()) {
 			return;
@@ -92,15 +92,13 @@ public:
 				continue;
 			}
 
-			if (line.startsWith("host ", Qt::CaseInsensitive)) {
+                        QString hostnamelong = line.section(" ",0,0);
+                        QString hostname = hostnamelong.section(",",0,0);
 
-				QString hostname = line.mid(5).trimmed();
+                        SSHHost host;
+                        host.name = hostname;
 
-				SSHHost host;
-				host.name = hostname;
-
-				(*list) << host;
-			}
+                        (*list) << host;
 		}
 
 		config.close();

--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -215,6 +215,8 @@ void SSHRunner::run(const Plasma::RunnerContext &context, const Plasma::QueryMat
 
 	QString command = QString("ssh %1").arg(host);
 
+        KConfigGroup config(KSharedConfig::openConfig(QStringLiteral("kdeglobals")), "General");
+        QString terminal = config.readPathEntry("TerminalApplication",QStringLiteral("konsole"));
 	QString konsole_command = QString(terminal+" -e \'%1\'").arg(command);
 
 	KRun::runCommand(konsole_command, 0);

--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -42,6 +42,10 @@
 struct SSHHost
 {
 	QString name;
+	bool operator== (const SSHHost &b) const
+        {
+            return (name == b.name);
+        }
 };
 
 class SSHConfigReader
@@ -99,7 +103,9 @@ public:
                                         SSHHost host;
                                         host.name = hostname;
 
-                                        (*list) << host;
+                                        if (!list->contains(host)) {
+                                                (*list) << host;
+                                        }
                                 }
                         }
 
@@ -126,7 +132,9 @@ public:
                                 SSHHost host;
                                 host.name = hostname;
 
-                                (*list) << host;
+                                if (!list->contains(host)) {
+                                        (*list) << host;
+                                }
                         }
 
                         knownhosts.close();

--- a/krunner-ssh/ssh.cpp
+++ b/krunner-ssh/ssh.cpp
@@ -31,6 +31,9 @@
 #include <KLocalizedString>
 #include <krun.h>
 #include <KShell>
+#include <KConfig>
+#include <KConfigGroup>
+#include <KSharedConfig>
 
 #include <iostream>
 
@@ -212,8 +215,6 @@ void SSHRunner::run(const Plasma::RunnerContext &context, const Plasma::QueryMat
 
 	QString command = QString("ssh %1").arg(host);
 
-        KConfigGroup config(KSharedConfig::openConfig(QStringLiteral("kdeglobals")), "General");
-        QString terminal = config.readPathEntry("TerminalApplication",QStringLiteral("konsole"));
 	QString konsole_command = QString(terminal+" -e \'%1\'").arg(command);
 
 	KRun::runCommand(konsole_command, 0);


### PR DESCRIPTION
This set of changes searches both the .ssh/config and .ssh/known_hosts files for hosts to add to its list

It also merges in the upstream changes to use the user's configured default terminal, and adds quoting of the -e string.